### PR TITLE
fix: 修复数据初始化类中的角色保存逻辑错误

### DIFF
--- a/src/main/java/cn/xryder/base/config/DataInitializer.java
+++ b/src/main/java/cn/xryder/base/config/DataInitializer.java
@@ -19,7 +19,8 @@ import java.time.LocalDateTime;
 @Configuration
 public class DataInitializer {
     @Bean
-    public CommandLineRunner loadData(UserRepo userRepository, RoleRepo roleRepo, UserRoleRepo userRoleRepo, RolePermissionRepo rolePermissionRepo, DepartmentRepo departmentRepo, PasswordEncoder passwordEncoder) {
+    public CommandLineRunner loadData(UserRepo userRepository, RoleRepo roleRepo, UserRoleRepo userRoleRepo,
+            RolePermissionRepo rolePermissionRepo, DepartmentRepo departmentRepo, PasswordEncoder passwordEncoder) {
         return args -> {
             if (userRepository.findById(Admin.username).isEmpty()) {
                 User admin = new User();
@@ -41,7 +42,7 @@ public class DataInitializer {
                 role2.setId(SystemRoleEnum.USER.getId());
                 role2.setName(SystemRoleEnum.USER.getName());
                 role2.setType(RoleTypeEnum.SYSTEM.getType());
-                roleRepo.save(role);
+                roleRepo.save(role2);
 
                 // 初始化默认用户的管理员角色
                 UserRole userRole = new UserRole();


### PR DESCRIPTION
在初始化数据库的时候，我发现了代码中的一个错误，在创建和保存第二个角色时，不小心重用了第一个角色的变量名。

## 错误代码位置

在`DataInitializer.java`的第37行左右，创建角色2后，你使用了`roleRepo.save(role)`而不是`roleRepo.save(role2)`，这导致程序尝试保存相同ID的角色两次，触发了乐观锁异常。

## 解决方案
帮你修改了，已发起pull requst，merge就OK啦，还有建议作者提交代码前先格式化并去除没有引用的包，这样的话对于协作更加方便噢~ヾ(≧▽≦*)o
```java
// ...
                // 角色2
                Role role2 = new Role();
                role2.setId(SystemRoleEnum.USER.getId());
                role2.setName(SystemRoleEnum.USER.getName());
                role2.setType(RoleTypeEnum.SYSTEM.getType());
                roleRepo.save(role2);  // 修改这里：保存role2而不是role
// ...
```